### PR TITLE
Exclude metadata for certain layers

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -103,6 +103,10 @@ const layersSetup = (layersOrder) => {
       layerObj.options?.["bypassDNA"] !== undefined
         ? layerObj.options?.["bypassDNA"]
         : false,
+    excludeMetadata:
+      layerObj.options?.["excludeMetadata"] !== undefined
+        ? layerObj.options?.["excludeMetadata"]
+        : false,
   }));
   return layers;
 };
@@ -173,10 +177,13 @@ const addMetadata = (_dna, _edition) => {
 
 const addAttributes = (_element) => {
   let selectedElement = _element.layer.selectedElement;
-  attributesList.push({
-    trait_type: _element.layer.name,
-    value: selectedElement.name,
-  });
+
+  if(!_element.layer.excludeMetadata){
+    attributesList.push({
+      trait_type: _element.layer.name,
+      value: selectedElement.name,
+    });
+  }
 };
 
 const loadLayerImg = async (_layer) => {
@@ -224,6 +231,7 @@ const constructLayerToDna = (_dna = "", _layers = []) => {
       name: layer.name,
       blend: layer.blend,
       opacity: layer.opacity,
+      excludeMetadata: layer.excludeMetadata,
       selectedElement: selectedElement,
     };
   });


### PR DESCRIPTION
There are times when we have multiple layers while buidling the NFT art but some of the layers are too minor details worth adding into the metadata. Hence we need a way to skip the metadata for certain layers even if they are used for the art generation. 

Solution is to add an extra option `excludeMetadata` at the layer level to skip the metadata for the specific layer. User doesn't need to speicify this option by default as it is false. Only if we want to exclude a layer from the metadata then it will be added to the layer configuraiton. Following is an example
```

{
        name: "Eye color",
        options: {
          excludeMetadata: true,
          displayName: "Awesome Eye Color",
        }
}
```